### PR TITLE
Allow numerical translation strings

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -2047,6 +2047,13 @@ class i18n extends Object implements TemplateGlobalProvider {
 
 				$translation = $adapter->translate($entity, $locale);
 
+				// In the event the translation is a number, make sure to cast it to a string. Without this,
+				// we cannot have a translatable value such as '3'. The cast to string is required so '0' is
+				// also allowed as a translation.
+				if (is_numeric($translation)) {
+					$translation = (string) $translation;
+				}
+
 					// Return translation only if we found a match thats not the entity itself (Zend fallback)
 				if(is_string($translation) && trim($translation) != '' && $translation != $entity) {
 						$returnValue = $translation;

--- a/tests/i18n/i18nTest.php
+++ b/tests/i18n/i18nTest.php
@@ -445,7 +445,51 @@ class i18nTest extends SapphireTest {
 		
 		i18n::set_locale($oldLocale);
 	}
-	
+
+	public function testTranslatedDataTypes() {
+		i18n::get_translator('core')->getAdapter()->addTranslation(array(
+			'i18nTestModule.INTEGER' => 1234,
+			'i18nTestModule.FLOAT' => 123.4235,
+			'i18nTestModule.ZERO' => 0,
+			'i18nTestModule.TRUE' => true,
+			'i18nTestModule.EMPTY' => '',
+			'i18nTestModule.WHITESPACE' => '       ',
+			'i18nTestModule.FANCYNUMBER' => '987,654,321.01',
+		), 'en_US');
+
+		$this->assertEquals(1234, i18n::_t('i18nTestModule.INTEGER'),
+			'Returns the translated integer'
+		);
+
+		$this->assertEquals(123.4235, i18n::_t('i18nTestModule.FLOAT'),
+			'Returns the translated float'
+		);
+
+		$this->assertEquals('987,654,321.01', i18n::_t('i18nTestModule.FANCYNUMBER'),
+			'Returns the fancy number'
+		);
+
+		$this->assertEquals(0, i18n::_t('i18nTestModule.ZERO'),
+			'Is able to return a zero'
+		);
+
+		$this->assertEquals('', i18n::_t('i18nTestModule.TRUE'),
+			'Returns blank string for bool(true)'
+		);
+
+		$this->assertEquals('', i18n::_t('i18nTestModule.FALSE'),
+			'Returns blank string for bool(false)'
+		);
+
+		$this->assertEquals('', i18n::_t('i18nTestModule.EMPTY'),
+			'Returns empty string for empty translation'
+		);
+
+		$this->assertEquals('', i18n::_t('i18nTestModule.WHITESPACE'),
+			'Returns empty string for whitespace only translation'
+		);
+	}
+
 	public function testIncludeByLocale() {
 		// Looping through modules, so we can test the translation autoloading
 		// Load non-exclusive to retain core class autoloading


### PR DESCRIPTION
In order to allow a value such as int(3) to be translated, we have to
make sure to cast it as a string before checking to see if the string
can be used.
