### PR TITLE
Speed up Unit Tests when using Temporary Database

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -750,7 +750,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	public static function empty_temp_db() {
 		if(self::using_temp_db()) {
 			$dbadmin = new DatabaseAdmin();
-			$dbadmin->clearAllData();
+			$dbadmin->clearDataByClone();
 			
 			// Some DataExtensions keep a static cache of information that needs to 
 			// be reset whenever the database is cleaned out

--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -225,11 +225,11 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 				//echo "Re-creating temp database... ";
 				self::create_temp_db();
 				//echo "done.\n";
+			} else {
+				self::empty_temp_db();
 			}
 
 			singleton('DataObject')->flushCache();
-			
-			self::empty_temp_db();
 			
 			foreach($this->requireDefaultRecordsFrom as $className) {
 				$instance = singleton($className);

--- a/model/DatabaseAdmin.php
+++ b/model/DatabaseAdmin.php
@@ -262,6 +262,22 @@ class DatabaseAdmin extends Controller {
 	}
 
 	/**
+	 * Clear all data out of the database by creating a copy of all the tables and deleting the old versions.
+	 */
+	public function clearDataByClone() {
+		$tables = DB::getConn()->tableList();
+		foreach($tables as $table) {
+			if(method_exists(DB::getConn(), 'clearTable')) {
+				DB::getConn()->clearTable($table);
+			} else {
+				DB::query("CREATE TABLE \"{$table}_new\" LIKE \"{$table}\"");
+				DB::query("RENAME TABLE \"{$table}\" TO \"{$table}_old\", \"{$table}_new\" TO \"{$table}\"");
+				DB::query("DROP TABLE \"{$table}_old\"");
+			}
+		}
+	}
+
+	/**
 	 * Remove invalid records from tables - that is, records that don't have
 	 * corresponding records in their parent class tables.
 	 */


### PR DESCRIPTION
This is a stopgap to speed up the unit tests. It decreases the time per test function from >60sec to ~5sec when using the database or a fixture file.

The `TRUNCATE` for the temp database has become very slow in recent weeks. Until we can improve the speed for `TRUNCATE` on MySQL, this allows us to "clone" the tables and delete the old versions. Not ideal, but it helps.
