### PR TITLE
Fix http error on GridField get actions

### DIFF
--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -206,11 +206,17 @@
 		 */
 		$('.ss-gridfield .action.no-ajax').entwine({
 			onclick: function(e){
-				var self = this, btn = this.closest(':button'), grid = this.getGridField(), 
-					form = this.closest('form'), data = form.find(':input.gridstate').serialize();
+				var self = this, btn = this.closest(':button'), grid = this.getGridField(),
+					form = this.closest('form'), data = form.find(':input.gridstate').serialize(),
+					csrf = form.find('input[name="SecurityID"]').val();
 
 				// Add current button
 				data += "&" + encodeURIComponent(btn.attr('name')) + '=' + encodeURIComponent(btn.val());
+
+				// Add csrf
+				if(csrf) {
+					data += "&SecurityID=" + encodeURIComponent(csrf);
+				}
 
 				// Include any GET parameters from the current URL, as the view
 				// state might depend on it. For example, a list pre-filtered


### PR DESCRIPTION
There was another commit that I missed cherry-picking with #2. :-/ This PR adds that commit, thereby restoring the functionality of GridField `get` actions.
