### PR TITLE
Cherrypick PHPUnit framework declaration changes

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -508,10 +508,11 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		$haystack,
 		$message = '',
 		$ignoreCase = FALSE,
-		$checkForObjectIdentity = TRUE
+		$checkForObjectIdentity = TRUE,
+		$checkForNonObjectIdentity = false
 	) {
 		if ($haystack instanceof DBField) $haystack = (string)$haystack;
-		parent::assertContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity);
+		parent::assertContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity, $checkForNonObjectIdentity);
 	}
 
 	public static function assertNotContains(
@@ -519,10 +520,11 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		$haystack,
 		$message = '',
 		$ignoreCase = FALSE,
-		$checkForObjectIdentity = TRUE
+		$checkForObjectIdentity = TRUE,
+		$checkForNonObjectIdentity = false
 	) {
 		if ($haystack instanceof DBField) $haystack = (string)$haystack;
-		parent::assertNotContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity);
+		parent::assertNotContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity, $checkForNonObjectIdentity);
 	}
 
 	/**


### PR DESCRIPTION
When running the unit tests using PHPUnit 4.8, the following error occurs: 

```
ERROR [Strict Notice]: Declaration of SapphireTest::assertNotContains() should be compatible with PHPUnit_Framework_Assert::assertNotContains, and the same error for assertContains()
```

This updates the `assertContains` declarations to match those needed by PHPUnit 4.8.
