### PR TITLE
Fixed GridField sorting but on last column

### DIFF
--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -40,16 +40,19 @@
 						// multiple relationships via keyboard.
 						if(focusedElName) self.find(':input[name="' + focusedElName + '"]').focus();
 
-						var content;
-						if(ajaxOpts.data[0].filter=="show"){	
-							content = '<span class="non-sortable"></span>';
-							self.addClass('show-filter').find('.filter-header').show();														
-						}else{
-							content = '<button name="showFilter" class="ss-gridfield-button-filter trigger"></button>';
-							self.removeClass('show-filter').find('.filter-header').hide();	
-						}
+						// Update filter 
+						if(self.find('.filter-header').length) {
+							var content;
+							if(ajaxOpts.data[0].filter=="show") {
+								content = '<span class="non-sortable"></span>';
+								self.addClass('show-filter').find('.filter-header').show();														
+							} else {
+								content = '<button name="showFilter" class="ss-gridfield-button-filter trigger"></button>';
+								self.removeClass('show-filter').find('.filter-header').hide();	
+							}
 
-						self.find('.sortable-header th:last').html(content);
+							self.find('.sortable-header th:last').html(content);
+						}
 
 						form.removeClass('loading');
 						if(successCallback) successCallback.apply(this, arguments);


### PR DESCRIPTION
GridField.js had a bug in it that was causing the header of the last column in the GridField to show a filter icon and was preventing sorting. To fix this bug I cherry picked the fix that exists in the 3.2 code into our repo.
