### PR TITLE
Remove obsolete class loaders from test listeners

### DIFF
--- a/dev/CliTestReporter.php
+++ b/dev/CliTestReporter.php
@@ -1,4 +1,9 @@
 <?php
+
+if(!class_exists('SapphireTestReporter')) {
+	return;
+}
+
 /**
  * Test reporter optimised for CLI (ie, plain-text) output
  *

--- a/dev/SapphireTestReporter.php
+++ b/dev/SapphireTestReporter.php
@@ -1,6 +1,8 @@
 <?php
-if(!class_exists('PHPUnit_Framework_TestResult', false)) require_once 'PHPUnit/Framework/TestResult.php';
-if(!class_exists('PHPUnit_Framework_TestListener', false)) require_once 'PHPUnit/Framework/TestListener.php';
+
+if(!interface_exists('PHPUnit_Framework_TestListener')) {
+	return;
+}
 
 /**#@+
  * @var int


### PR DESCRIPTION
When running the i18n collector with PHPUnit installed via composer, the `require_once` commands cause an error. As such cherry-picking this commit from SS 4.